### PR TITLE
Changes to error callbacks

### DIFF
--- a/lib/flickr.js
+++ b/lib/flickr.js
@@ -147,7 +147,10 @@ exports.Flickr.prototype.processResponse = function(response_body, options, call
       ourCallback(null, res);
   } else {
       
-      ourCallback(new Error("Flickr Error ("+res.code+"): " + res.message));;
+      var error = new Error(res.message);
+      error.statusCode = res.code;
+
+      ourCallback(error);
   }
   
 

--- a/lib/flickr.js
+++ b/lib/flickr.js
@@ -71,9 +71,12 @@ exports.Flickr.prototype._executeOAuthAPIRequest = function(params, options, cal
   var queryString = this.paramsToQueryString(params);
 
   var request = this.oauth_client.get("https://api.flickr.com" + this.baseUrl + queryString, 
-                          oauth_token, oauth_token_secret, function(error, data){
-    if (error) {
-      callback(new Error("Flickr Error ("+error.statusCode+"): message: "+error.data));
+                          oauth_token, oauth_token_secret, function(err, data){
+    if (err) {
+      var error = new Error(err.data);
+      error.statusCode = err.statusCode;
+
+      callback(error);
     } else {
       flickr_instance.processResponse(data, options, callback);
     }


### PR DESCRIPTION
- Add the Flickr response status as part of the error that is returned on the callback if we did not get an ok from the API. This is helpful for debugging reasons.
- Do not change the error that we receive from Flickr. Let the developer decide what to do with the real message and that may include adding "Flickr Error: ".
